### PR TITLE
Fix: avoid invalid cast in `AI_TurnToWP` (#4)

### DIFF
--- a/src/Externals/Externals_AI.hpp
+++ b/src/Externals/Externals_AI.hpp
@@ -12,7 +12,7 @@ namespace GOTHIC_NAMESPACE
 
 		if (wp)
 		{
-			t_npc->GetEM(0)->OnMessage(new oCMsgMovement(oCMsgMovement::EV_TURNTOVOB, (zCVob*)wp), t_npc);
+			t_npc->GetEM(0)->OnMessage(new oCMsgMovement(oCMsgMovement::EV_TURNTOPOS, wp->GetPositionWorld()), t_npc);
 			return;
 		}
 
@@ -21,7 +21,7 @@ namespace GOTHIC_NAMESPACE
 
 		if (!vob) return;
 
-		t_npc->GetEM(0)->OnMessage(new oCMsgMovement(oCMsgMovement::EV_TURNTOVOB, vob), t_npc);
+		t_npc->GetEM(0)->OnMessage(new oCMsgMovement(oCMsgMovement::EV_TURNTOPOS, vob->GetPositionWorld()), t_npc);
 	}
 
 	static void AI_TurnToVob(oCNpc* t_npc, const zSTRING& t_pointName)
@@ -34,6 +34,6 @@ namespace GOTHIC_NAMESPACE
 
 		if (!vob) return;
 
-		t_npc->GetEM(0)->OnMessage(new oCMsgMovement(oCMsgMovement::EV_TURNTOVOB, vob), t_npc);
+		t_npc->GetEM(0)->OnMessage(new oCMsgMovement(oCMsgMovement::EV_TURNTOPOS, vob->GetPositionWorld()), t_npc);
 	}
 }


### PR DESCRIPTION
- Replaced cast of `zCWaypoint*` to `zCVob*` in `AI_TurnToWP` with proper use of `EV_TURNOPOS` event.
- Now sends position (`wp->GetPositionWorld()`) instead of casting waypoint pointer. It applies also for `AI_TurnToVob`.

Closes #4.