### PR TITLE
Fix: safely delete `zCMenuItem` for G1/G1A (#3)

### DIFF
--- a/src/Externals/Externals_Menu.hpp
+++ b/src/Externals/Externals_Menu.hpp
@@ -12,11 +12,7 @@ namespace GOTHIC_NAMESPACE
         if (!menuItem) return;
 
         menuItem->SetText(t_text, t_line, t_drawNow);
-#if ENGINE > Engine_G2
-        menuItem->Release();
-#else
-        delete menuItem;
-#endif
+        MenuItem_Release(menuItem);
     }
 
     static zSTRING Menu_GetItemText(const zSTRING& t_name, const int t_line)
@@ -37,11 +33,7 @@ namespace GOTHIC_NAMESPACE
             log->Warning("Menu item '{0}' has no value at {1} text line.", name.ToChar(), t_line);
         }
 
-#if ENGINE > Engine_G2
-        menuItem->Release();
-#else
-        delete menuItem;
-#endif
+        MenuItem_Release(menuItem);
         return result;
     }
 
@@ -66,11 +58,7 @@ namespace GOTHIC_NAMESPACE
         if (!menuItem) return 0;
 
         menuItem->SetText(menuItemText, line, drawNow);
-#if ENGINE >= Engine_G2
-        menuItem->Release();
-#else
-        delete menuItem;
-#endif
+        MenuItem_Release(menuItem);
         return 0;
     }
 
@@ -101,11 +89,7 @@ namespace GOTHIC_NAMESPACE
         if (result.IsEmpty())
             log->Warning("Menu item '{0}' has no value at {1} text line.", menuItemName.ToChar(), line);
 
-#if ENGINE >= Engine_G2
-        menuItem->Release();
-#else
-        delete menuItem;
-#endif
+        MenuItem_Release(menuItem);
         par->SetReturn(result);
         return 0;
     }

--- a/src/Externals/Helpers.hpp
+++ b/src/Externals/Helpers.hpp
@@ -104,4 +104,18 @@ namespace GOTHIC_NAMESPACE
             (t_str.PickWord_Old(2, "\r\t ").ToFloat()),
             (t_str.PickWord_Old(3, "\r\t ").ToFloat()));
     }
+
+    void MenuItem_Release(zCMenuItem* t_menuItem)
+    {
+        if (!t_menuItem) return;
+
+#if ENGINE >= Engine_G2
+        t_menuItem->Release();
+#else
+        t_menuItem->m_iRefCtr--;
+
+        if (t_menuItem->m_iRefCtr <= 0 && !t_menuItem->registeredCPP)
+            delete t_menuItem;
+#endif
+    }
 }


### PR DESCRIPTION
The previous deletion logic used a raw 'delete' on `zCMenuItem` in G1/G1A, which could cause issues if the object was still referenced elsewhere.

Updated to match G2 behavior by manually managing ref count and checking registeredCPP.

Closes #3.